### PR TITLE
Initial Python scaffold for DRY context runtime (context compiler + CLI)

### DIFF
--- a/PROJECT.md
+++ b/PROJECT.md
@@ -1,0 +1,30 @@
+# Dry Context Runtime (Fresh Start)
+
+A new Python project for building **DRY for AI** runtime orchestration.
+
+## Core idea
+
+Define context once, then compile minimal per-call projections:
+
+- **Definition DRY**: reusable context blocks and inheritance
+- **Transmission DRY**: only inject relevant blocks for each call
+- **Storage DRY**: summarize older outputs and keep references
+- **Reasoning DRY**: cache decisions and re-use them when valid
+
+## Quick start
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+dry-context plan --config examples/runtime.yaml --agent architect --task design
+```
+
+## Configuration model
+
+- `blocks`: canonical context atoms (single source of truth)
+- `profiles`: named compositions of blocks (e.g. base/system/workflow)
+- `agents`: per-agent inheritance and add-ons
+- `policies`: selection rules for when a block applies
+
+See `examples/runtime.yaml`.

--- a/dry_context_runtime/__init__.py
+++ b/dry_context_runtime/__init__.py
@@ -1,0 +1,5 @@
+"""Dry Context Runtime package."""
+
+from .engine import ContextRuntime
+
+__all__ = ["ContextRuntime"]

--- a/dry_context_runtime/cli.py
+++ b/dry_context_runtime/cli.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import argparse
+import json
+
+from .engine import ContextRuntime
+from .models import RuntimeState
+from .store import ConfigLoader
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="DRY context runtime")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    plan = sub.add_parser("plan", help="Compute minimal injection plan")
+    plan.add_argument("--config", required=True)
+    plan.add_argument("--agent", required=True)
+    plan.add_argument("--task", required=True)
+    plan.add_argument("--workflow", default="default")
+    plan.add_argument("--cached", nargs="*", default=[])
+
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    if args.command == "plan":
+        config = ConfigLoader.load(args.config)
+        runtime = ContextRuntime(config)
+        state = RuntimeState(cached_blocks=set(args.cached))
+        plan = runtime.plan_call(
+            agent_id=args.agent,
+            task=args.task,
+            workflow=args.workflow,
+            state=state,
+        )
+
+        payload = {
+            "required": sorted(plan.required),
+            "inject": sorted(plan.inject),
+            "keep_cached": sorted(plan.keep_cached),
+            "evict": sorted(plan.evict),
+            "prompt_segments": runtime.materialize(plan.inject),
+        }
+        print(json.dumps(payload, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/dry_context_runtime/engine.py
+++ b/dry_context_runtime/engine.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from .models import PlanResult, RuntimeState
+from .policy import PolicyEngine
+from .store import RuntimeConfig
+
+
+class ContextRuntime:
+    """Compile minimal context projections for each call."""
+
+    def __init__(self, config: RuntimeConfig) -> None:
+        self.config = config
+
+    def plan_call(
+        self,
+        *,
+        agent_id: str,
+        task: str,
+        workflow: str,
+        state: RuntimeState,
+    ) -> PlanResult:
+        agent = self.config.agents[agent_id]
+        required = set()
+
+        for profile in agent.extends:
+            required.update(self.config.resolve_profile(profile))
+        required.update(agent.adds)
+
+        required = PolicyEngine.apply(
+            rules=self.config.policies,
+            signal={"agent": agent_id, "task": task, "workflow": workflow},
+            current=required,
+        )
+
+        inject = required - state.cached_blocks
+        keep_cached = required & state.cached_blocks
+        evict = state.cached_blocks - required
+
+        return PlanResult(required=required, inject=inject, keep_cached=keep_cached, evict=evict)
+
+    def materialize(self, block_ids: set[str]) -> list[str]:
+        return [self.config.blocks[b].content for b in sorted(block_ids) if b in self.config.blocks]

--- a/dry_context_runtime/models.py
+++ b/dry_context_runtime/models.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ContextBlock:
+    id: str
+    content: str
+    tags: set[str] = field(default_factory=set)
+    token_estimate: int = 0
+
+
+@dataclass(frozen=True)
+class AgentSpec:
+    id: str
+    extends: list[str] = field(default_factory=list)
+    adds: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class PolicyRule:
+    id: str
+    when: dict[str, Any]
+    include: list[str] = field(default_factory=list)
+    exclude: list[str] = field(default_factory=list)
+
+
+@dataclass
+class RuntimeState:
+    """In-memory cache snapshot for a conversation/session."""
+
+    cached_blocks: set[str] = field(default_factory=set)
+    summary_refs: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class PlanResult:
+    required: set[str]
+    inject: set[str]
+    keep_cached: set[str]
+    evict: set[str]

--- a/dry_context_runtime/policy.py
+++ b/dry_context_runtime/policy.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from .models import PolicyRule
+
+
+class PolicyEngine:
+    @staticmethod
+    def apply(
+        *,
+        rules: list[PolicyRule],
+        signal: dict[str, str],
+        current: set[str],
+    ) -> set[str]:
+        result = set(current)
+        for rule in rules:
+            if PolicyEngine._matches(rule, signal):
+                result.update(rule.include)
+                result.difference_update(rule.exclude)
+        return result
+
+    @staticmethod
+    def _matches(rule: PolicyRule, signal: dict[str, str]) -> bool:
+        for key, expected in rule.when.items():
+            if signal.get(key) != expected:
+                return False
+        return True

--- a/dry_context_runtime/store.py
+++ b/dry_context_runtime/store.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+from .models import AgentSpec, ContextBlock, PolicyRule
+
+
+@dataclass
+class RuntimeConfig:
+    blocks: dict[str, ContextBlock]
+    profiles: dict[str, list[str]]
+    agents: dict[str, AgentSpec]
+    policies: list[PolicyRule]
+
+    def resolve_profile(self, profile_name: str) -> set[str]:
+        seen: set[str] = set()
+
+        def _visit(name: str) -> None:
+            if name in seen:
+                return
+            seen.add(name)
+            for item in self.profiles.get(name, []):
+                if item.startswith("profile:"):
+                    _visit(item.split(":", 1)[1])
+
+        _visit(profile_name)
+        resolved: set[str] = set()
+        for name in seen:
+            for item in self.profiles.get(name, []):
+                if not item.startswith("profile:"):
+                    resolved.add(item)
+        return resolved
+
+
+class ConfigLoader:
+    @staticmethod
+    def load(path: str | Path) -> RuntimeConfig:
+        raw = yaml.safe_load(Path(path).read_text())
+
+        blocks = {
+            key: ContextBlock(
+                id=key,
+                content=value.get("content", ""),
+                tags=set(value.get("tags", [])),
+                token_estimate=value.get("token_estimate", 0),
+            )
+            for key, value in raw.get("blocks", {}).items()
+        }
+
+        profiles = raw.get("profiles", {})
+        agents = {
+            key: AgentSpec(
+                id=key,
+                extends=value.get("extends", []),
+                adds=value.get("adds", []),
+            )
+            for key, value in raw.get("agents", {}).items()
+        }
+
+        policies = [
+            PolicyRule(
+                id=p.get("id", f"policy-{idx}"),
+                when=p.get("when", {}),
+                include=p.get("include", []),
+                exclude=p.get("exclude", []),
+            )
+            for idx, p in enumerate(raw.get("policies", []), start=1)
+        ]
+
+        return RuntimeConfig(blocks=blocks, profiles=profiles, agents=agents, policies=policies)

--- a/examples/runtime.yaml
+++ b/examples/runtime.yaml
@@ -1,0 +1,59 @@
+blocks:
+  system.role:
+    content: "You are a helpful assistant."
+    tags: [system]
+    token_estimate: 8
+  system.safety:
+    content: "Follow safety rules and decline unsafe actions."
+    tags: [system, safety]
+    token_estimate: 10
+  system.output_json:
+    content: "Respond with strict JSON only."
+    tags: [system, output]
+    token_estimate: 6
+  user.concise:
+    content: "User prefers concise answers."
+    tags: [user]
+    token_estimate: 5
+  workflow.plugin_context:
+    content: "Project is PluginX with modular architecture."
+    tags: [workflow]
+    token_estimate: 9
+  workflow.research_context:
+    content: "Research goals and preferred source quality."
+    tags: [workflow]
+    token_estimate: 8
+  agent.architect.style:
+    content: "Prioritize modular design and tradeoff analysis."
+    tags: [agent]
+    token_estimate: 8
+
+profiles:
+  base:
+    - system.role
+    - system.safety
+    - system.output_json
+    - user.concise
+  plugin_workflow:
+    - workflow.plugin_context
+  research_workflow:
+    - workflow.research_context
+
+agents:
+  architect:
+    extends: [base]
+    adds: [agent.architect.style]
+
+policies:
+  - id: plugin-workflow-rule
+    when:
+      workflow: plugin
+    include: [workflow.plugin_context]
+  - id: research-workflow-rule
+    when:
+      workflow: research
+    include: [workflow.research_context]
+  - id: skip-json-for-brainstorm
+    when:
+      task: brainstorm
+    exclude: [system.output_json]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "dry-context-runtime"
+version = "0.1.0"
+description = "DRY-first context compiler for multi-agent LLM orchestration"
+readme = "PROJECT.md"
+requires-python = ">=3.10"
+dependencies = [
+  "pyyaml>=6.0",
+]
+
+[project.scripts]
+dry-context = "dry_context_runtime.cli:main"
+
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+packages = ["dry_context_runtime"]


### PR DESCRIPTION
### Motivation
- Provide a small, executable runtime that implements the "define once, inject minimally" approach for multi-agent LLM contexts to avoid prompt duplication and unnecessary token transmission.
- Create a compact prototype to model canonical context atoms, agent inheritance, and policy-driven selective injection so the projector/caching ideas can be iterated on quickly.

### Description
- Added a new Python package `dry_context_runtime` implementing core datamodels (`ContextBlock`, `AgentSpec`, `PolicyRule`, `RuntimeState`, `PlanResult`) in `models.py`.
- Implemented a YAML config loader and profile resolver in `store.py` to load canonical `blocks`, `profiles`, `agents`, and `policies` from a single source of truth.
- Implemented a simple `PolicyEngine` in `policy.py` and a `ContextRuntime` engine in `engine.py` that computes `required`, `inject`, `keep_cached`, and `evict` sets and materializes prompt segments.
- Added a CLI entrypoint `dry-context plan` in `cli.py` to compute plans and emit JSON, an example configuration `examples/runtime.yaml`, project metadata `pyproject.toml`, and a `PROJECT.md` overview.

### Testing
- Compiled the package with `python -m compileall dry_context_runtime` which succeeded.
- Ran the planner end-to-end using `python -m dry_context_runtime.cli plan --config examples/runtime.yaml --agent architect --task design --workflow plugin` which produced the expected JSON plan and prompt segments (succeeded).
- Ran an additional scenario with cached blocks using `python -m dry_context_runtime.cli plan --config examples/runtime.yaml --agent architect --task brainstorm --workflow research --cached system.role system.safety` which produced the expected `inject`/`keep_cached` outputs (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b56ab4203083319c0de4e19df1a8a8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `dry-context` CLI tool for computing minimal context injection plans based on agent profiles, tasks, and workflows.
  * New project documentation describing the Dry Context Runtime framework and configuration model.
  * Configuration-driven context management supporting blocks, profiles, agents, and policies.

* **Chores**
  * Added package metadata, dependencies, and CLI entry point configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->